### PR TITLE
Add Apple Notes clone (Vanilla JS) and GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-apple-notes-pages.yml
+++ b/.github/workflows/deploy-apple-notes-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy Apple Notes app to GitHub Pages
+
+on:
+  push:
+    branches: ["main", "master", "work"]
+    paths:
+      - "apple-notes-app/**"
+      - ".github/workflows/deploy-apple-notes-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apple-notes-app
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apple-notes-app/README.md
+++ b/apple-notes-app/README.md
@@ -1,0 +1,31 @@
+# Apple Notes App (Vanilla JS)
+
+A lightweight Apple Notes-style web app.
+
+## Features
+- Create notes
+- Edit title and content
+- Search notes
+- Delete notes
+- Auto-save to `localStorage`
+
+## Run locally
+```bash
+cd apple-notes-app
+python3 -m http.server 8000
+```
+Then open <http://localhost:8000>.
+
+## Publish publicly (GitHub Pages)
+This repository includes a workflow that deploys `apple-notes-app/` to GitHub Pages when you push changes.
+
+### One-time setup
+1. Push this repository to GitHub.
+2. In GitHub: **Settings → Pages**.
+3. Under **Build and deployment**, set **Source** to **GitHub Actions**.
+4. Push to `main`, `master`, or `work` branch (or run the workflow manually).
+
+### Public URL
+After deployment, your public app URL will be:
+
+`https://<your-github-username>.github.io/<your-repo-name>/`

--- a/apple-notes-app/index.html
+++ b/apple-notes-app/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Apple Notes Clone</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar">
+        <header class="sidebar-header">
+          <h1>Notes</h1>
+          <button id="new-note" aria-label="Create new note">+</button>
+        </header>
+        <input id="search" type="search" placeholder="Search notes" />
+        <ul id="notes-list" class="notes-list"></ul>
+      </aside>
+
+      <main class="editor">
+        <input
+          id="note-title"
+          class="note-title"
+          type="text"
+          placeholder="Title"
+        />
+        <textarea
+          id="note-content"
+          class="note-content"
+          placeholder="Start typing..."
+        ></textarea>
+      </main>
+    </div>
+
+    <template id="note-item-template">
+      <li class="note-item">
+        <button class="note-select" type="button">
+          <h3 class="item-title"></h3>
+          <p class="item-preview"></p>
+          <time class="item-date"></time>
+        </button>
+        <button class="delete-note" type="button" aria-label="Delete note">🗑</button>
+      </li>
+    </template>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/apple-notes-app/script.js
+++ b/apple-notes-app/script.js
@@ -1,0 +1,132 @@
+const STORAGE_KEY = "apple-notes-clone-v1";
+
+const notesListEl = document.getElementById("notes-list");
+const newNoteBtn = document.getElementById("new-note");
+const searchEl = document.getElementById("search");
+const titleEl = document.getElementById("note-title");
+const contentEl = document.getElementById("note-content");
+const itemTemplate = document.getElementById("note-item-template");
+
+let notes = loadNotes();
+let selectedNoteId = notes[0]?.id || null;
+
+if (!notes.length) {
+  createNote();
+}
+
+render();
+
+newNoteBtn.addEventListener("click", () => {
+  createNote();
+  render();
+});
+
+searchEl.addEventListener("input", render);
+
+titleEl.addEventListener("input", () => updateSelectedNote());
+contentEl.addEventListener("input", () => updateSelectedNote());
+
+function createNote() {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const note = {
+    id,
+    title: "New Note",
+    content: "",
+    updatedAt: now,
+  };
+  notes.unshift(note);
+  selectedNoteId = id;
+  persist();
+}
+
+function updateSelectedNote() {
+  const note = notes.find((n) => n.id === selectedNoteId);
+  if (!note) return;
+
+  note.title = titleEl.value.trim() || "Untitled";
+  note.content = contentEl.value;
+  note.updatedAt = new Date().toISOString();
+
+  notes.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+  persist();
+  render();
+}
+
+function removeNote(id) {
+  notes = notes.filter((n) => n.id !== id);
+  if (!notes.length) {
+    createNote();
+  }
+  if (!notes.some((n) => n.id === selectedNoteId)) {
+    selectedNoteId = notes[0].id;
+  }
+  persist();
+  render();
+}
+
+function render() {
+  const query = searchEl.value.trim().toLowerCase();
+  const filtered = notes.filter((n) => {
+    const text = `${n.title} ${n.content}`.toLowerCase();
+    return text.includes(query);
+  });
+
+  notesListEl.innerHTML = "";
+  filtered.forEach((note) => {
+    const fragment = itemTemplate.content.cloneNode(true);
+    const root = fragment.querySelector(".note-item");
+    const selectBtn = fragment.querySelector(".note-select");
+    const deleteBtn = fragment.querySelector(".delete-note");
+
+    fragment.querySelector(".item-title").textContent = note.title;
+    fragment.querySelector(".item-preview").textContent = note.content.slice(0, 70) || "No additional text";
+    fragment.querySelector(".item-date").textContent = new Date(note.updatedAt).toLocaleString();
+
+    if (note.id === selectedNoteId) {
+      root.classList.add("active");
+    }
+
+    selectBtn.addEventListener("click", () => {
+      selectedNoteId = note.id;
+      render();
+    });
+
+    deleteBtn.addEventListener("click", (event) => {
+      event.stopPropagation();
+      removeNote(note.id);
+    });
+
+    notesListEl.appendChild(fragment);
+  });
+
+  hydrateEditor();
+}
+
+function hydrateEditor() {
+  const selected = notes.find((n) => n.id === selectedNoteId);
+  if (!selected) {
+    titleEl.value = "";
+    contentEl.value = "";
+    return;
+  }
+
+  titleEl.value = selected.title;
+  contentEl.value = selected.content;
+}
+
+function loadNotes() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed;
+  } catch {
+    return [];
+  }
+}
+
+function persist() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+}

--- a/apple-notes-app/style.css
+++ b/apple-notes-app/style.css
@@ -1,0 +1,153 @@
+:root {
+  color-scheme: light;
+  --bg: #f3f3f7;
+  --card: #ffffff;
+  --text: #1c1c1e;
+  --muted: #6e6e73;
+  --accent: #ffcc00;
+  --border: #d2d2d7;
+}
+
+* {
+  box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar,
+.editor {
+  padding: 1rem;
+}
+
+.sidebar {
+  background: #ececf2;
+  border-right: 1px solid var(--border);
+}
+
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.sidebar-header h1 {
+  margin: 0;
+  font-size: 1.7rem;
+}
+
+#new-note {
+  border: none;
+  background: var(--accent);
+  border-radius: 50%;
+  width: 2rem;
+  height: 2rem;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+#search {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.notes-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.note-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.note-select {
+  text-align: left;
+  border: none;
+  background: transparent;
+  padding: 0.7rem;
+  cursor: pointer;
+}
+
+.note-item.active {
+  border-color: var(--accent);
+  box-shadow: inset 4px 0 0 var(--accent);
+}
+
+.item-title {
+  margin: 0 0 0.2rem;
+  font-size: 1rem;
+}
+
+.item-preview,
+.item-date {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.delete-note {
+  border: none;
+  background: transparent;
+  padding: 0.7rem;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+.editor {
+  display: grid;
+  gap: 0.75rem;
+  background: var(--card);
+}
+
+.note-title,
+.note-content {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem;
+  font-size: 1rem;
+}
+
+.note-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.note-content {
+  resize: none;
+  min-height: calc(100vh - 7rem);
+  line-height: 1.5;
+}
+
+@media (max-width: 840px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .note-content {
+    min-height: 50vh;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight Apple Notes–style web app implemented in plain HTML/CSS/JS for easy hosting and experimentation.
- Persist notes locally in the browser using `localStorage` and offer basic CRUD and search functionality.
- Enable automatic publishing of the `apple-notes-app/` directory to GitHub Pages via an Actions workflow.

### Description
- Add a new `apple-notes-app/` directory containing `index.html`, `style.css`, and `script.js` that implement the notes UI, editor, search, and `localStorage` persistence.
- Include a `README.md` in `apple-notes-app/` with run instructions and GitHub Pages publish guidance, including the local run command `python3 -m http.server 8000`.
- Add a GitHub Actions workflow `/.github/workflows/deploy-apple-notes-pages.yml` that triggers on pushes to `main`, `master`, or `work`, uploads `apple-notes-app` as a Pages artifact, and deploys it using `actions/deploy-pages@v4`.
- Implement client behavior in `script.js` including `createNote`, `updateSelectedNote`, `removeNote`, `loadNotes`, and `persist` with UUID note IDs and sorting by `updatedAt`.

### Testing
- No automated tests were executed for this change; the PR adds a GitHub Pages deployment workflow but no CI test suite was run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efa208e5a083328793f522f95d97d8)